### PR TITLE
'just notify groupmembers' feature rewritten/optimized for Moodle 2.8

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2014101800;
-$plugin->requires  = 2014051200;        // require moodle 2.7 or higher
+$plugin->version   = 2015031201;
+$plugin->requires  = 2014111000;        // require moodle 2.8 or higher
 $plugin->release   = '1.4';
 $plugin->maturity  = MATURITY_RC;
 $plugin->component = 'local_reminders';       


### PR DESCRIPTION
`groupmembersonly` was deprecated and removed in 2.8, see #8.

Course and cm object retrieval optimized with new functions provided by moodle 2.8 (real cm_info object was also needed for the compatibility changes):
[Moodle 2.8 release notes: API changes](https://docs.moodle.org/dev/Moodle_2.8_release_notes#API_changes)

Replaced old `groupmembersonly` check and `groups_get_grouping_members($cm->groupingid)` with `\core_availability\info_module($cm)->filter_user_list($sendusers)`.
[Availability API](https://docs.moodle.org/dev/Availability_API#Display_a_list_of_users_who_may_be_able_to_access_the_current_activity)

Attention: patch not compatible with moodle version < 2.8