### PR TITLE
Fix cron errors resulting from new role

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -80,11 +80,11 @@ function local_reminders_cron() {
         $flag = 0;
         foreach ($allroles as $arole) {
             $roleoptionactivity = $CFG->local_reminders_activityroles;
-            if ($roleoptionactivity[$flag] == '1') {
+            if (isset($roleoptionactivity[$flag]) && $roleoptionactivity[$flag] == '1') {
                 $activityroleids[] = $arole->id;
             }
             $roleoption = $CFG->local_reminders_courseroles;
-            if ($roleoption[$flag] == '1') {
+            if (isset($roleoption[$flag]) && $roleoption[$flag] == '1') {
                 $courseroleids[] = $arole->id;
             }
             $flag++;


### PR DESCRIPTION
After an admin adds a role to the Moodle instance, the cron repeatedly throws error messages until an admin goes into the local/reminders configuration page and saves the configuration.  This commits fixes that problem.