### PR TITLE
Remove require_login on a lib file

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -22,6 +22,9 @@
  * @copyright  2012 Isuru Madushanka Weerarathna
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+defined('MOODLE_INTERNAL') || die();
+
 require_once($CFG->dirroot . '/local/reminders/reminder.class.php');
 require_once($CFG->dirroot . '/local/reminders/contents/site_reminder.class.php');
 require_once($CFG->dirroot . '/local/reminders/contents/user_reminder.class.php');
@@ -55,8 +58,6 @@ DEFINE('REMINDERS_ACTIVITY_ONLY_CLOSINGS', 62);
 
 DEFINE('REMINDERS_SEND_AS_NO_REPLY', 70);
 DEFINE('REMINDERS_SEND_AS_ADMIN', 71);
-
-require_login();
 
 /// FUNCTIONS ///////////////////////////////////////////////////////////
 


### PR DESCRIPTION
I'm not sure why this `require_login()` has been added, but it causes a infinite redirection loop during upgrade / install.

To reproduce, take a not up to date Moodle, update the code and try to run an upgrade (web interface or command line).
Here's the output of the command line `upgrade.php --non-interactive`:
```
-->local_reminders
Default exception handler: Unsupported redirect detected, script execution terminated Debug: 
Error code: redirecterrordetected
* line 2740 of /lib/weblib.php: moodle_exception thrown
* line 2642 of /lib/moodlelib.php: call to redirect()
* line 59 of /local/reminders/lib.php: call to require_login()
* line 32 of /local/reminders/classes/task/send_reminders.php: call to require_once()
* line 114 of /lib/classes/component.php: call to include_once()
* line ? of unknownfile: call to core_component::classloader()
* line ? of unknownfile: call to spl_autoload_call()
* line 290 of /lib/classes/task/manager.php: call to class_exists()
* line 68 of /lib/classes/task/manager.php: call to core\task\manager::scheduled_task_from_record()
* line 88 of /lib/classes/task/manager.php: call to core\task\manager::load_default_scheduled_tasks_for_component()
* line 648 of /lib/upgradelib.php: call to core\task\manager::reset_scheduled_tasks_for_component()
* line 1857 of /lib/upgradelib.php: call to upgrade_plugins()
* line 182 of /admin/cli/upgrade.php: call to upgrade_noncore()

!!! Unsupported redirect detected, script execution terminated !!!
!! 
Error code: redirecterrordetected !!
!! Stack trace: * line 2740 of /lib/weblib.php: moodle_exception thrown
* line 2642 of /lib/moodlelib.php: call to redirect()
* line 59 of /local/reminders/lib.php: call to require_login()
* line 32 of /local/reminders/classes/task/send_reminders.php: call to require_once()
* line 114 of /lib/classes/component.php: call to include_once()
* line ? of unknownfile: call to core_component::classloader()
* line ? of unknownfile: call to spl_autoload_call()
* line 290 of /lib/classes/task/manager.php: call to class_exists()
* line 68 of /lib/classes/task/manager.php: call to core\task\manager::scheduled_task_from_record()
* line 88 of /lib/classes/task/manager.php: call to core\task\manager::load_default_scheduled_tasks_for_component()
* line 648 of /lib/upgradelib.php: call to core\task\manager::reset_scheduled_tasks_for_component()
* line 1857 of /lib/upgradelib.php: call to upgrade_plugins()
* line 182 of /admin/cli/upgrade.php: call to upgrade_noncore()
 !!
```