### PR TITLE
Improve reminder accuracy by checking for activity submissions

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
+          ini-values: max_input_vars=5000
 
       - name: Initialise moodle-plugin-ci
         run: |

--- a/classes/local/completion_status.php
+++ b/classes/local/completion_status.php
@@ -1,0 +1,85 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_reminders\local;
+
+use cm_info;
+use core_component;
+
+/**
+ * Helper class to determine the status of activities for users in a course.
+ *
+ * @package     local_reminders
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia Pty Ltd
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class completion_status {
+    /** @var array A cache of instantiated status providers. */
+    private static $statusproviders = [];
+
+    /**
+     * Check if the activity is considered complete for the given user.
+     *
+     * @param int $userid The user id.
+     * @param cm_info $cm The course module object.
+     * @return bool True if the activity is considered complete, false otherwise.
+     */
+    public static function is_completed(int $userid, cm_info $cm): bool {
+        // Let supported activity types determine completion status.
+        $statusprovider = self::get_completion_status_provider($cm->modname);
+        if ($statusprovider) {
+            return $statusprovider->is_completed($userid, $cm);
+        }
+
+        $statusprovider = new completion_status_provider();
+        return $statusprovider->is_completed($userid, $cm);
+    }
+
+    /**
+     * Get a submission status completion_status_provider for a given module name.
+     *
+     * @param string $modname The name of the module (e.g. 'assign', 'quiz').
+     * @return completion_status_provider|null A completion_status_provider instance, or null if not supported.
+     */
+    private static function get_completion_status_provider(string $modname): ?completion_status_provider {
+
+        if (isset(self::$statusproviders[$modname])) {
+            return self::$statusproviders[$modname];
+        }
+
+        // Check if this is a valid, installed Moodle plugin component.
+        if (empty(core_component::get_component_directory("mod_{$modname}"))) {
+            self::$statusproviders[$modname] = null;
+            return null;
+        }
+
+        $classname = __NAMESPACE__ . "\\status_provider\\mod_{$modname}";
+        if (!class_exists($classname)) {
+            self::$statusproviders[$modname] = null;
+            return null;
+        }
+
+        $statusprovider = new $classname();
+        if (!$statusprovider instanceof completion_status_provider) {
+            self::$statusproviders[$modname] = null;
+            return null;
+        }
+
+        self::$statusproviders[$modname] = $statusprovider;
+        return $statusprovider;
+    }
+}

--- a/classes/local/completion_status_provider.php
+++ b/classes/local/completion_status_provider.php
@@ -1,0 +1,52 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_reminders\local;
+
+use cm_info;
+use completion_info;
+
+/**
+ * Default class for activity completion status providers.
+ *
+ * @package     local_reminders
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia Pty Ltd
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class completion_status_provider {
+    /**
+     * Check if the activity is considered complete.
+     *
+     * @param int $userid The user id.
+     * @param cm_info $cm The course module object.
+     * @return bool True if the user has made a submission, false otherwise.
+     */
+    public function is_completed(int $userid, cm_info $cm): bool {
+        $completion = new completion_info($cm->get_course());
+
+        if ($completion->is_enabled($cm)) {
+            switch ($completion->get_data($cm, false, $userid)->completionstate) {
+                case COMPLETION_COMPLETE:
+                case COMPLETION_COMPLETE_PASS:
+                case COMPLETION_COMPLETE_FAIL:
+                    return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/classes/local/status_provider/mod_assign.php
+++ b/classes/local/status_provider/mod_assign.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_reminders\local\status_provider;
+
+use assign;
+use cm_info;
+use local_reminders\local\completion_status_provider;
+
+/**
+ * Submission status provider for assignments.
+ *
+ * @package     local_reminders
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia Pty Ltd
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_assign extends completion_status_provider {
+    /**
+     * {@inheritDoc}
+     *
+     * @param int $userid The user id.
+     * @param cm_info $cm The course module object.
+     * @return bool True if the user has made a submission, false otherwise.
+     */
+    public function is_completed(int $userid, cm_info $cm): bool {
+        global $CFG, $DB;
+
+        require_once($CFG->dirroot . '/mod/assign/locallib.php');
+
+        $assignment = new assign($cm->context, $cm, $cm->get_course());
+        $instance = $assignment->get_instance($userid);
+
+        if ($instance->teamsubmission) {
+            $submission = $assignment->get_group_submission($userid, 0, false);
+        } else {
+            $submission = $assignment->get_user_submission($userid, false);
+        }
+
+        if (is_object($submission) && isset($submission->status)) {
+            return $submission->status === ASSIGN_SUBMISSION_STATUS_SUBMITTED;
+        }
+
+        return parent::is_completed($userid, $cm);
+    }
+}

--- a/classes/local/status_provider/mod_quiz.php
+++ b/classes/local/status_provider/mod_quiz.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_reminders\local\status_provider;
+
+use cm_info;
+use local_reminders\local\completion_status_provider;
+
+/**
+ * Submission status provider for quizzes.
+ *
+ * @package     local_reminders
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia Pty Ltd
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_quiz extends completion_status_provider {
+    /**
+     * {@inheritDoc}
+     *
+     * @param int $userid The user id.
+     * @param cm_info $cm The course module object.
+     * @return bool True if the user has made a submission, false otherwise.
+     */
+    public function is_completed(int $userid, cm_info $cm): bool {
+        global $CFG;
+
+        require_once($CFG->dirroot . '/mod/quiz/locallib.php');
+
+        if (count(quiz_get_user_attempts($cm->instance, $userid)) > 0) {
+            return true;
+        }
+
+        return parent::is_completed($userid, $cm);
+    }
+}

--- a/contents/activity_handlers.class.php
+++ b/contents/activity_handlers.class.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use local_reminders\local\completion_status;
+
 defined('MOODLE_INTERNAL') || die;
 
 /**
@@ -104,13 +106,8 @@ abstract class local_reminder_activity_handler {
      * @return bool true if completed. false otherwise.
      */
     protected function check_completion_status($course, $coursemodule, $userid) {
-        $completion = new completion_info($course);
-        if ($completion->is_enabled($coursemodule)) {
-            return $completion->get_data($coursemodule, false, $userid)->completionstate;
-        }
-        return false;
+        return completion_status::is_completed($userid, $coursemodule);
     }
-
 }
 
 /**

--- a/tests/local/status_provider/mod_assign_test.php
+++ b/tests/local/status_provider/mod_assign_test.php
@@ -1,0 +1,121 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_reminders\local\status_provider;
+
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/assign/tests/generator.php');
+
+use advanced_testcase;
+use local_reminders\local\completion_status;
+use mod_assign_test_generator;
+
+/**
+ * Test status class.
+ *
+ * @package     local_reminders
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia Pty Ltd
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class mod_assign_test extends advanced_testcase {
+    // Include the assign test generator helper trait.
+    use mod_assign_test_generator;
+
+    /**
+     * Test return values of get_status.
+     *
+     * @covers ::is_completed
+     */
+    public function test_get_status(): void {
+        global $CFG, $DB;
+
+        $this->resetAfterTest();
+        $CFG->enablecompletion = true;
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        // Assignment that requires submission and grading to complete.
+        $assign1 = $this->create_instance($course, [
+            'assignsubmission_onlinetext_enabled' => 1,
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
+            'completionsubmit' => 1,
+            'completionusegrade' => 1,
+        ]);
+
+        // Assignment that requires submission, grading and a passing grade to complete.
+        $assign2 = $this->create_instance($course, [
+            'assignsubmission_onlinetext_enabled' => 1,
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
+            'completionsubmit' => 1,
+            'completionusegrade' => 1,
+            'completionpassgrade' => 1,
+            'gradepass' => 50,
+        ]);
+
+        $teacher = $this->getDataGenerator()->create_and_enrol($course, 'teacher');
+        $student1 = $this->getDataGenerator()->create_and_enrol($course);
+        $student2 = $this->getDataGenerator()->create_and_enrol($course);
+
+        // Check the initial status of assignments.
+        $this->assertFalse(completion_status::is_completed($student1->id, $assign1->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student1->id, $assign2->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign1->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign2->get_course_module()));
+
+        // Add a draft submission for student 1.
+        $this->add_submission($student1, $assign1, 'Assignment submission text alpha.');
+        $this->add_submission($student1, $assign2, 'Graded assignment submission text alpha.');
+
+        $this->assertFalse(completion_status::is_completed($student1->id, $assign1->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student1->id, $assign2->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign1->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign2->get_course_module()));
+
+        // Submit assignment for student 1.
+        $this->submit_for_grading($student1, $assign1);
+        $this->submit_for_grading($student1, $assign2);
+
+        $this->assertTrue(completion_status::is_completed($student1->id, $assign1->get_course_module()));
+        $this->assertTrue(completion_status::is_completed($student1->id, $assign2->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign1->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign2->get_course_module()));
+
+        // Resubmit assignments for student 1 before grading.
+        $this->add_submission($student1, $assign1, 'Assignment submission text beta.');
+        $this->add_submission($student1, $assign2, 'Graded assignment submission text beta.');
+        $this->submit_for_grading($student1, $assign1);
+        $this->submit_for_grading($student1, $assign2);
+
+        // Since the assignment has not been graded yet, the status should still be submitted.
+        $this->assertTrue(completion_status::is_completed($student1->id, $assign1->get_course_module()));
+        $this->assertTrue(completion_status::is_completed($student1->id, $assign2->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign1->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign2->get_course_module()));
+
+        // Grade the assignments for student 1.
+        $this->mark_submission($teacher, $assign1, $student1, 25.0);
+        $this->mark_submission($teacher, $assign2, $student1, 25.0);
+
+        $this->assertTrue(completion_status::is_completed($student1->id, $assign1->get_course_module()));
+        $this->assertTrue(completion_status::is_completed($student1->id, $assign2->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign1->get_course_module()));
+        $this->assertFalse(completion_status::is_completed($student2->id, $assign2->get_course_module()));
+    }
+}

--- a/tests/local/status_provider/mod_page_test.php
+++ b/tests/local/status_provider/mod_page_test.php
@@ -1,0 +1,70 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_reminders\local\status_provider;
+
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/assign/tests/generator.php');
+
+use advanced_testcase;
+use completion_info;
+use local_reminders\local\completion_status;
+
+/**
+ * Test status class.
+ *
+ * @package     local_reminders
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia Pty Ltd
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class mod_page_test extends advanced_testcase {
+    /**
+     * Test return values of get_status.
+     *
+     * @covers ::is_completed
+     */
+    public function test_get_status(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        // Page activity that requires viewing to complete.
+        $page = $this->getDataGenerator()->create_module('page', [
+            'course' => $course->id,
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
+            'completionview' => 1,
+        ]);
+
+        $student1 = $this->getDataGenerator()->create_and_enrol($course);
+        $student2 = $this->getDataGenerator()->create_and_enrol($course);
+
+        // Simulate the student viewing the page to trigger completion.
+        $modinfo = get_fast_modinfo($course);
+        $cm = $modinfo->get_cm($page->cmid);
+        $completion = new completion_info($course);
+        $completion->set_module_viewed($cm, $student2->id);
+
+        // Check if the page activity is marked as completed for the student.
+        $this->assertFalse(completion_status::is_completed($student1->id, $cm));
+        $this->assertTrue(completion_status::is_completed($student2->id, $cm));
+    }
+}

--- a/tests/local/status_provider/mod_quiz_test.php
+++ b/tests/local/status_provider/mod_quiz_test.php
@@ -1,0 +1,135 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_reminders\local\status_provider;
+
+use completion_info;
+use advanced_testcase;
+use local_reminders\local\completion_status;
+use question_engine;
+
+/**
+ * Test status class for quizzes.
+ *
+ * @package     local_reminders
+ * @author      Alexander Van der Bellen <alexandervanderbellen@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia Pty Ltd
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class mod_quiz_test extends advanced_testcase {
+    /**
+     * Helper function to set up a quiz with one numerical question.
+     *
+     * @param int $courseid The course id where the quiz will be created.
+     * @return object The created quiz instance.
+     */
+    private function setup_quiz(int $courseid): object {
+        // Create a quiz.
+        $quizgenerator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');
+        $quiz = $quizgenerator->create_instance([
+            'course' => $courseid,
+            'grade' => 100.0,
+            'sumgrades' => 1,
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
+        ]);
+
+        // Add a question.
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $cat = $questiongenerator->create_question_category();
+        $question = $questiongenerator->create_question('numerical', null, ['category' => $cat->id]);
+        quiz_add_quiz_question($question->id, $quiz);
+
+        return $quiz;
+    }
+
+    /**
+     * Helper function for tests.
+     * Starts an attempt, processes responses and finishes the attempt.
+     *
+     * @param array $attemptoptions ['quiz'] => object, ['student'] => object, ['tosubmit'] => array, ['attemptnumber'] => int
+     */
+    private function do_attempt_quiz(array $attemptoptions): void {
+        $quizobj = \mod_quiz\quiz_settings::create((int) $attemptoptions['quiz']->id);
+
+        // Start the passing attempt.
+        $quba = question_engine::make_questions_usage_by_activity('mod_quiz', $quizobj->get_context());
+        $quba->set_preferred_behaviour($quizobj->get_quiz()->preferredbehaviour);
+
+        $timenow = time();
+        $attempt = quiz_create_attempt(
+            $quizobj,
+            $attemptoptions['attemptnumber'],
+            false,
+            $timenow,
+            false,
+            $attemptoptions['student']->id
+        );
+        quiz_start_new_attempt($quizobj, $quba, $attempt, $attemptoptions['attemptnumber'], $timenow);
+        quiz_attempt_save_started($quizobj, $quba, $attempt);
+
+        // Process responses from the student.
+        $attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
+        $attemptobj->process_submitted_actions($timenow, false, $attemptoptions['tosubmit']);
+
+        // Finish the attempt.
+        $attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
+        $this->assertTrue($attemptobj->has_response_to_at_least_one_graded_question());
+        $attemptobj->process_finish($timenow, false);
+    }
+
+    /**
+     * Test return values of get_status.
+     *
+     * @covers ::is_completed
+     */
+    public function test_get_status(): void {
+        global $CFG, $DB;
+
+        if (!class_exists('\mod_quiz\quiz_settings') || !class_exists('\mod_quiz\quiz_attempt')) {
+            $this->markTestSkipped('mod_quiz API is not available.');
+        }
+
+        $this->resetAfterTest(true);
+        $CFG->enablecompletion = true;
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => true]);
+        $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
+        $quiz = $this->setup_quiz($course->id);
+        $modinfo = get_fast_modinfo($course);
+        $cm = $modinfo->get_cm($quiz->cmid);
+
+        // Check intial status.
+        $this->assertFalse(completion_status::is_completed($student->id, $cm));
+
+        // Complete an attempt and check status is submitted.
+        $this->do_attempt_quiz([
+            'quiz' => $quiz,
+            'student' => $student,
+            'attemptnumber' => 1,
+            'tosubmit' => [1 => ['answer' => '3.14']],
+        ]);
+        $this->assertTrue(completion_status::is_completed($student->id, $cm));
+
+        // Update completion criteria and check status is completed.
+        $DB->update_record('course_modules', [
+            'id' => $cm->id,
+            'completionpassgrade' => 1,
+        ]);
+        $completion = new completion_info($course);
+        $completion->update_state($cm, COMPLETION_UNKNOWN, $student->id);
+        $this->assertTrue(completion_status::is_completed($student->id, $cm));
+    }
+}


### PR DESCRIPTION
This pull request resolves an issue where students received overdue reminders for work they had already submitted. Previously, the plugin relied solely on the core activity completion status. This caused problems because completion is often tied to receiving a grade, which rarely happens before the due date, leading to incorrect reminders for submitted work.

This patch introduces a lightweight and extensible framework that checks for activity submissions in addition to the core completion status. This ensures reminders are only sent when a submission is actually missing, providing a more accurate and less confusing experience for students.

The new submission check, along with unit tests, has been implemented for assignments and quizzes. Support for additional modules can be added easily.

Fixes #142.